### PR TITLE
Use Geocoder instead of directly hitting trash endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1310,6 +1310,11 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@scarf/scarf": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-0.1.5.tgz",
+      "integrity": "sha512-Fx6atDc7JM1r0WkPCDhNetVZNp+DO21q/HGlomAKBG+k8vb1B8fg8Yige4oCf1P9OWTZWm5tM5i3jlXhrSbNOg=="
+    },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
@@ -10708,6 +10713,14 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "react-query": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-1.2.0.tgz",
+      "integrity": "sha512-BtMfJqRTFY1D4T6FvTp8JD+xNjA7tsCpxUhz9JihfJ7zsbRywD7hf1ypSuCO38Ifdo1pe4ID4Bw9HWl/wvc2Ng==",
+      "requires": {
+        "@scarf/scarf": "^0.1.3"
+      }
     },
     "react-scripts": {
       "version": "3.4.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-query": "^1.2.0",
     "react-scripts": "3.4.1",
     "use-debounce": "^3.4.0",
     "whatwg-fetch": "^3.0.0"

--- a/src/App.js
+++ b/src/App.js
@@ -9,34 +9,35 @@ import { useQuery } from "react-query";
 
 const { setConfig, getValue } = Config;
 
-const testApiRoot =
-  "https://testservices.baltimorecountymd.gov/api/hub/collectionSchedule";
-const prodApiRoot =
-  "https://services.baltimorecountymd.gov/api/hub/collectionSchedule";
+const addressLookupEndpoint = "api/gis/addressLookup";
+const collectionScheduleEndpoint = "api/hub/collectionSchedule";
+
+const testApiRoot = `https://testservices.baltimorecountymd.gov/${collectionScheduleEndpoint}`;
+const prodApiRoot = `https://services.baltimorecountymd.gov/${collectionScheduleEndpoint}`;
 
 // HACK - the Config utility does not account for beta.
 // TODO: This will need to be addressed when we get closer to launch
-const localApiRoot =
-  window.location.hostname.indexOf("beta") > -1
-    ? testApiRoot
-    : "http://localhost:53001/api/Schedule";
+
+const isBeta = window.location.hostname.indexOf("beta") > -1;
+const localApiRoot = isBeta
+  ? testApiRoot
+  : "http://localhost:53001/api/Schedule";
+const localAddressLookup = isBeta
+  ? `https://testservices.baltimorecountymd.gov/${addressLookupEndpoint}`
+  : `http://localhost:54727/${addressLookupEndpoint}`;
 
 const configValues = {
   local: {
     apiRoot: localApiRoot,
-    addressLookupEndpoint: "http://localhost:54727/api/gis/addresslookup",
+    addressLookupEndpoint: localAddressLookup,
   },
   development: {
     apiRoot: testApiRoot,
-    addressLookupEndpoint: "",
-  },
-  staging: {
-    apiRoot: testApiRoot,
-    addressLookupEndpoint: "",
+    addressLookupEndpoint: localAddressLookup,
   },
   production: {
     apiRoot: prodApiRoot,
-    addressLookupEndpoint: "",
+    addressLookupEndpoint: `https://services.baltimorecountymd.gov/${addressLookupEndpoint}`,
   },
 };
 
@@ -52,7 +53,7 @@ const fetchSchedule = (key, address) =>
 
 function App() {
   const [address, setAddress] = useState(null);
-  const { status, data, error, isFetching } = useQuery(
+  const { data, error, isFetching } = useQuery(
     address && ["getSchedule", address],
     fetchSchedule
   );

--- a/src/App.js
+++ b/src/App.js
@@ -24,31 +24,31 @@ const localApiRoot =
 const configValues = {
   local: {
     apiRoot: localApiRoot,
-    addressLookupEndpoint: "http://localhost:54727/api/gis/addresslookup"
+    addressLookupEndpoint: "http://localhost:54727/api/gis/addresslookup",
   },
   development: {
     apiRoot: testApiRoot,
-    addressLookupEndpoint: ""
+    addressLookupEndpoint: "",
   },
   staging: {
     apiRoot: testApiRoot,
-    addressLookupEndpoint: ""
+    addressLookupEndpoint: "",
   },
   production: {
     apiRoot: prodApiRoot,
-    addressLookupEndpoint: ""
-  }
+    addressLookupEndpoint: "",
+  },
 };
 
 setConfig(configValues);
 
-const fetchAddresses = addressQuery =>
-  fetch(`${getValue("addressLookupEndpoint")}/${addressQuery}`).then(res =>
+const fetchAddresses = (addressQuery) =>
+  fetch(`${getValue("addressLookupEndpoint")}/${addressQuery}`).then((res) =>
     res.json()
   );
 
 const fetchSchedule = (key, address) =>
-  fetch(`${getValue("apiRoot")}/${address}`).then(res => res.json());
+  fetch(`${getValue("apiRoot")}/${address}`).then((res) => res.json());
 
 function App() {
   const [address, setAddress] = useState(null);
@@ -58,14 +58,11 @@ function App() {
   );
   const suggest = async (query, populateResults) => {
     const addresses = await fetchAddresses(query);
-    const filteredResults = addresses.map(
-      ({ City, StreetAddress, Zip }) => `${StreetAddress} ${City} ${Zip}`
-    );
-    populateResults(filteredResults);
+    populateResults(addresses);
   };
 
-  const handleValueSelect = selectedValue => {
-    setAddress(selectedValue);
+  const handleValueSelect = (selectedValue) => {
+    setAddress(selectedValue.StreetAddress);
   };
 
   return (

--- a/src/App.js
+++ b/src/App.js
@@ -22,23 +22,29 @@ const localApiRoot =
 
 const configValues = {
   local: {
-    apiRoot: localApiRoot
+    apiRoot: localApiRoot,
+    addressLookupEndpoint: "http://localhost:54727/api/gis/addresslookup"
   },
   development: {
-    apiRoot: testApiRoot
+    apiRoot: testApiRoot,
+    addressLookupEndpoint: ""
   },
   staging: {
-    apiRoot: testApiRoot
+    apiRoot: testApiRoot,
+    addressLookupEndpoint: ""
   },
   production: {
-    apiRoot: prodApiRoot
+    apiRoot: prodApiRoot,
+    addressLookupEndpoint: ""
   }
 };
 
 setConfig(configValues);
 
 const fetchAddresses = addressQuery =>
-  fetch(`${getValue("apiRoot")}/${addressQuery}`).then(res => res.json());
+  fetch(`${getValue("addressLookupEndpoint")}/${addressQuery}`).then(res =>
+    res.json()
+  );
 
 function App() {
   const [schedule, setSchedule] = useState({});
@@ -46,7 +52,9 @@ function App() {
   const suggest = async (query, populateResults) => {
     const addresses = await fetchAddresses(query);
     setResults(addresses);
-    const filteredResults = addresses.map(result => result.address);
+    const filteredResults = addresses.map(
+      ({ City, StreetAddress, Zip }) => `${StreetAddress} ${City} ${Zip}`
+    );
     populateResults(filteredResults);
   };
 

--- a/src/App.js
+++ b/src/App.js
@@ -62,7 +62,9 @@ function App() {
   };
 
   const handleValueSelect = (selectedValue) => {
-    setAddress(selectedValue.StreetAddress);
+    if (selectedValue) {
+      setAddress(selectedValue.StreetAddress);
+    }
   };
 
   return (

--- a/src/App.js
+++ b/src/App.js
@@ -66,6 +66,12 @@ function App() {
     }
   };
 
+  if (error) {
+    return (
+      <p>Something went wrong. Please try again in a couple of minutes.</p>
+    );
+  }
+
   return (
     <div className="App">
       {!data && (

--- a/src/App.js
+++ b/src/App.js
@@ -3,44 +3,14 @@ import React, { useState } from "react";
 import Autocomplete from "./components/Autocomplete";
 import { Config } from "@baltimorecounty/javascript-utilities";
 import Fetch from "./common/Fetch";
+import { Run } from "./Startup";
 import Schedule from "./components/Schedule";
 import { useQuery } from "react-query";
 
-const { setConfig, getValue } = Config;
+const { getValue } = Config;
 
-const addressLookupEndpoint = "api/gis/addressLookup";
-const collectionScheduleEndpoint = "api/hub/collectionSchedule";
-
-const testApiRoot = `https://testservices.baltimorecountymd.gov/${collectionScheduleEndpoint}`;
-const prodApiRoot = `https://services.baltimorecountymd.gov/${collectionScheduleEndpoint}`;
-
-// HACK - the Config utility does not account for beta.
-// TODO: This will need to be addressed when we get closer to launch
-
-const isBeta = window.location.hostname.indexOf("beta") > -1;
-const localApiRoot = isBeta
-  ? testApiRoot
-  : "http://localhost:53001/api/Schedule";
-const localAddressLookup = isBeta
-  ? `https://testservices.baltimorecountymd.gov/${addressLookupEndpoint}`
-  : `http://localhost:54727/${addressLookupEndpoint}`;
-
-const configValues = {
-  local: {
-    apiRoot: localApiRoot,
-    addressLookupEndpoint: localAddressLookup,
-  },
-  development: {
-    apiRoot: testApiRoot,
-    addressLookupEndpoint: localAddressLookup,
-  },
-  production: {
-    apiRoot: prodApiRoot,
-    addressLookupEndpoint: `https://services.baltimorecountymd.gov/${addressLookupEndpoint}`,
-  },
-};
-
-setConfig(configValues);
+// Run our Startup Code
+Run();
 
 function App() {
   const [address, setAddress] = useState(null);

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import React, { useState } from "react";
 import Autocomplete from "./components/Autocomplete";
 import { Config } from "@baltimorecounty/javascript-utilities";
 import Fetch from "./common/Fetch";
+import { FormatAddress } from "./common/Formatters";
 import { Run } from "./Startup";
 import Schedule from "./components/Schedule";
 import { useQuery } from "react-query";
@@ -13,11 +14,15 @@ const { getValue } = Config;
 Run();
 
 function App() {
-  const [address, setAddress] = useState(null);
+  const [address, setAddress] = useState({});
+  const hasAddress = Object.keys(address).length > 0;
   const { data, error, isFetching } = useQuery(
-    address && [
+    hasAddress && [
       "getSchedule",
-      { endpoint: getValue("apiRoot"), path: address },
+      {
+        endpoint: getValue("apiRoot"),
+        path: address.StreetAddress,
+      },
     ],
     Fetch
   );
@@ -31,9 +36,7 @@ function App() {
   };
 
   const handleValueSelect = (selectedValue) => {
-    if (selectedValue) {
-      setAddress(selectedValue.StreetAddress);
-    }
+    setAddress(selectedValue ? selectedValue : {});
   };
 
   if (error) {
@@ -53,11 +56,14 @@ function App() {
           minLength={3}
         />
       )}
-      {address && isFetching && <p>Loading Schedule...</p>}
-      {!isFetching && data && (
+      {hasAddress && isFetching && <p>Loading Schedule...</p>}
+      {hasAddress && !isFetching && data && (
         <div className="results">
-          <p>Selected Address: {address}</p>
-          <Schedule selectedAddress={address} schedule={data[0]} />
+          <p>Selected Address: {FormatAddress(address)}</p>
+          <Schedule
+            selectedAddress={address.StreetAddress}
+            schedule={data[0]}
+          />
         </div>
       )}
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,8 @@
-import "whatwg-fetch";
-
 import React, { useState } from "react";
 
 import Autocomplete from "./components/Autocomplete";
 import { Config } from "@baltimorecounty/javascript-utilities";
+import Fetch from "./common/Fetch";
 import Schedule from "./components/Schedule";
 import { useQuery } from "react-query";
 
@@ -43,22 +42,21 @@ const configValues = {
 
 setConfig(configValues);
 
-const fetchAddresses = (addressQuery) =>
-  fetch(`${getValue("addressLookupEndpoint")}/${addressQuery}`).then((res) =>
-    res.json()
-  );
-
-const fetchSchedule = (key, address) =>
-  fetch(`${getValue("apiRoot")}/${address}`).then((res) => res.json());
-
 function App() {
   const [address, setAddress] = useState(null);
   const { data, error, isFetching } = useQuery(
-    address && ["getSchedule", address],
-    fetchSchedule
+    address && [
+      "getSchedule",
+      { endpoint: getValue("apiRoot"), path: address },
+    ],
+    Fetch
   );
+
   const suggest = async (query, populateResults) => {
-    const addresses = await fetchAddresses(query);
+    const addresses = await Fetch("address", {
+      endpoint: getValue("addressLookupEndpoint"),
+      path: query,
+    });
     populateResults(addresses);
   };
 

--- a/src/Startup.js
+++ b/src/Startup.js
@@ -1,0 +1,44 @@
+import { Config } from "@baltimorecounty/javascript-utilities";
+
+const { setConfig } = Config;
+
+const addressLookupEndpoint = "api/gis/addressLookup";
+const collectionScheduleEndpoint = "api/hub/collectionSchedule";
+
+const testApiRoot = `https://testservices.baltimorecountymd.gov/${collectionScheduleEndpoint}`;
+const prodApiRoot = `https://services.baltimorecountymd.gov/${collectionScheduleEndpoint}`;
+
+// HACK - the Config utility does not account for beta.
+// TODO: This will need to be addressed when we get closer to launch
+
+const isBeta = window.location.hostname.indexOf("beta") > -1;
+const localApiRoot = isBeta
+  ? testApiRoot
+  : "http://localhost:53001/api/Schedule";
+const localAddressLookup = isBeta
+  ? `https://testservices.baltimorecountymd.gov/${addressLookupEndpoint}`
+  : `http://localhost:54727/${addressLookupEndpoint}`;
+
+const configValues = {
+  local: {
+    apiRoot: localApiRoot,
+    addressLookupEndpoint: localAddressLookup,
+  },
+  development: {
+    apiRoot: testApiRoot,
+    addressLookupEndpoint: localAddressLookup,
+  },
+  production: {
+    apiRoot: prodApiRoot,
+    addressLookupEndpoint: `https://services.baltimorecountymd.gov/${addressLookupEndpoint}`,
+  },
+};
+
+/**
+ * Runs startup code for our create react app
+ */
+const Run = () => {
+  setConfig(configValues);
+};
+
+export { Run };

--- a/src/common/Fetch.js
+++ b/src/common/Fetch.js
@@ -1,0 +1,13 @@
+import "whatwg-fetch";
+
+/**
+ *
+ * @param {string} key unique key for the fetch request
+ * @param {object} object
+ * @param {object.endpoint} api endpoint
+ * @param {object.path} path path for endpoint (path)
+ */
+const Fetch = (key, { endpoint, path }) =>
+  fetch(`${endpoint}/${path}`).then((res) => res.json());
+
+export default Fetch;

--- a/src/common/Fetch.js
+++ b/src/common/Fetch.js
@@ -1,7 +1,7 @@
 import "whatwg-fetch";
 
 /**
- *
+ * Wrapper for https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
  * @param {string} key unique key for the fetch request
  * @param {object} object
  * @param {object.endpoint} api endpoint

--- a/src/common/Formatters.js
+++ b/src/common/Formatters.js
@@ -1,0 +1,4 @@
+const CapitalizeFirstLetter = (string) =>
+  string.charAt(0).toUpperCase() + string.slice(1);
+
+export { CapitalizeFirstLetter };

--- a/src/common/Formatters.js
+++ b/src/common/Formatters.js
@@ -1,4 +1,15 @@
-const CapitalizeFirstLetter = (string) =>
+const capitalizeFirstLetter = (string) =>
   string.charAt(0).toUpperCase() + string.slice(1);
 
-export { CapitalizeFirstLetter };
+/**
+ * Format an address to a friendly format
+ */
+const FormatAddress = (address = {}) =>
+  address
+    ? `${address.StreetAddress} ${address.City} ${address.Zip}`
+        .split(" ")
+        .map((item) => capitalizeFirstLetter(item))
+        .join(" ")
+    : "";
+
+export { FormatAddress };

--- a/src/components/Autocomplete.jsx
+++ b/src/components/Autocomplete.jsx
@@ -12,6 +12,12 @@ const Autocomplete = ({ id, suggest, label, ...rest }) => {
     debouncedCallback(query, populateResults);
   };
 
+  const templateFn = (address) => {
+    return address
+      ? `${address.StreetAddress} ${address.City} ${address.Zip}`
+      : "";
+  };
+
   return (
     <div className="dg_form-field">
       {label && (
@@ -24,6 +30,10 @@ const Autocomplete = ({ id, suggest, label, ...rest }) => {
         className="dg_form-field_input--text"
         source={handleSource}
         showNoOptionsFound={false}
+        templates={{
+          inputValue: templateFn,
+          suggestion: templateFn,
+        }}
         {...rest}
       />
     </div>
@@ -36,7 +46,7 @@ Autocomplete.prototypes = {
   /** Label to describe the input */
   label: PropTypes.string,
   /** Suggest function populates the autocomplete values */
-  suggest: PropTypes.func.isRequired
+  suggest: PropTypes.func.isRequired,
 };
 
 export default Autocomplete;

--- a/src/components/Autocomplete.jsx
+++ b/src/components/Autocomplete.jsx
@@ -17,14 +17,13 @@ const Autocomplete = ({ id, suggest, label, ...rest }) => {
    * Template used to display autocomplete results
    * @param {object} address parts of an address
    */
-  const templateFn = (address) => {
-    return address
+  const templateFn = (address) =>
+    address
       ? `${address.StreetAddress} ${address.City} ${address.Zip}`
           .split(" ")
           .map((item) => CapitalizeFirstLetter(item))
           .join(" ")
       : "";
-  };
 
   return (
     <div className="dg_form-field">

--- a/src/components/Autocomplete.jsx
+++ b/src/components/Autocomplete.jsx
@@ -1,5 +1,6 @@
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 
+import { CapitalizeFirstLetter } from "../common/Formatters";
 import PropTypes from "prop-types";
 import React from "react";
 import UkAutocomplete from "accessible-autocomplete/react";
@@ -12,10 +13,6 @@ const Autocomplete = ({ id, suggest, label, ...rest }) => {
     debouncedCallback(query, populateResults);
   };
 
-  function capitalizeFirstLetter(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
-  }
-
   /**
    * Template used to display autocomplete results
    * @param {object} address parts of an address
@@ -24,7 +21,7 @@ const Autocomplete = ({ id, suggest, label, ...rest }) => {
     return address
       ? `${address.StreetAddress} ${address.City} ${address.Zip}`
           .split(" ")
-          .map((item) => capitalizeFirstLetter(item))
+          .map((item) => CapitalizeFirstLetter(item))
           .join(" ")
       : "";
   };

--- a/src/components/Autocomplete.jsx
+++ b/src/components/Autocomplete.jsx
@@ -1,6 +1,6 @@
 import "accessible-autocomplete/dist/accessible-autocomplete.min.css";
 
-import { CapitalizeFirstLetter } from "../common/Formatters";
+import { FormatAddress } from "../common/Formatters";
 import PropTypes from "prop-types";
 import React from "react";
 import UkAutocomplete from "accessible-autocomplete/react";
@@ -12,18 +12,6 @@ const Autocomplete = ({ id, suggest, label, ...rest }) => {
   const handleSource = (query, populateResults) => {
     debouncedCallback(query, populateResults);
   };
-
-  /**
-   * Template used to display autocomplete results
-   * @param {object} address parts of an address
-   */
-  const templateFn = (address) =>
-    address
-      ? `${address.StreetAddress} ${address.City} ${address.Zip}`
-          .split(" ")
-          .map((item) => CapitalizeFirstLetter(item))
-          .join(" ")
-      : "";
 
   return (
     <div className="dg_form-field">
@@ -38,8 +26,8 @@ const Autocomplete = ({ id, suggest, label, ...rest }) => {
         source={handleSource}
         showNoOptionsFound={false}
         templates={{
-          inputValue: templateFn,
-          suggestion: templateFn,
+          inputValue: FormatAddress,
+          suggestion: FormatAddress,
         }}
         {...rest}
       />

--- a/src/components/Autocomplete.jsx
+++ b/src/components/Autocomplete.jsx
@@ -12,9 +12,20 @@ const Autocomplete = ({ id, suggest, label, ...rest }) => {
     debouncedCallback(query, populateResults);
   };
 
+  function capitalizeFirstLetter(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+  }
+
+  /**
+   * Template used to display autocomplete results
+   * @param {object} address parts of an address
+   */
   const templateFn = (address) => {
     return address
       ? `${address.StreetAddress} ${address.City} ${address.Zip}`
+          .split(" ")
+          .map((item) => capitalizeFirstLetter(item))
+          .join(" ")
       : "";
   };
 

--- a/src/components/Schedule.jsx
+++ b/src/components/Schedule.jsx
@@ -11,7 +11,7 @@ import PropTypes from "prop-types";
 import React from "react";
 
 const Schedule = ({ schedule = {} }) => {
-  const { collectionSchedules } = schedule;
+  const { collectionSchedules = [] } = schedule;
   const hasAtLeastOneSchedule = collectionSchedules.some(
     schedule => schedule.nextCollectionDate
   );


### PR DESCRIPTION
In order to provide all the functionality being requested, we need to break up gis calls. We weren't able to get the GIS tools quickly enough.

This is the first step in breaking up the logic.

Make a request to the address lookup to get an address. Pass that address to the trash lookup service to get the schedule.