### PR TITLE
Fixed key for Beta

### DIFF
--- a/src/Startup.js
+++ b/src/Startup.js
@@ -20,7 +20,7 @@ const buildApiUrls = (endpoint) => {
   const isBeta = window.location.hostname.indexOf("beta") > -1;
   return Object.keys(hosts).reduce((prev, currentKey) => {
     prev[currentKey] = isBeta
-      ? `${hosts["test"]}/${endpoint}`
+      ? `${hosts["staging"]}/${endpoint}`
       : `${hosts[currentKey]}/${endpoint}`;
     return prev;
   }, {});


### PR DESCRIPTION
The startup code used the wrong key to point to testservices when the app is used on the beta site. This addresses that issue.